### PR TITLE
fix: adding await clause when fetching previous week's userpoll

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -593,11 +593,11 @@ const getUserpoll = async (week, pollDate) => {
 	}
 
 	//Here, we want to just match the current week's rankings against the last week
-	currentUserPoll = getUserPollFromBallots(ballotListCurrent);
-	lastWeekUserPoll = getUserPollFromBallots(lastWeekBallotsList);
+	currentUserPoll = await getUserPollFromBallots(ballotListCurrent);
+	lastWeekUserPoll =  await getUserPollFromBallots(lastWeekBallotsList);
 	computeTeamDeltas(currentPoll,lastWeekUserPoll);
 
-	return currentUserPoll
+	return currentUserPoll;
 
 
 	// for (let i = 0; i < ballots.length; i++) {


### PR DESCRIPTION
this adds 2 await clauses to the fetching of last week's ballots, to fix the bug that toastify noted